### PR TITLE
fix: template ability routing + DB-backed creature types

### DIFF
--- a/bin/pf2_enrich_abilities
+++ b/bin/pf2_enrich_abilities
@@ -31,7 +31,7 @@ from pfsrd2.sql.enrichment import (
     update_enriched_json,
     update_is_uma,
 )
-from pfsrd2.ability_enrichment import _deterministic_category
+from pfsrd2.ability_placement import deterministic_ability_category
 from pfsrd2.enrichment.regex_extractor import ENRICHMENT_VERSION
 from pfsrd2.sql.monster_abilities import fetch_monster_abilities_by_name
 
@@ -248,7 +248,7 @@ def run_llm(conn, args):
 
 def _deterministic_category_from_raw(raw_json):
     """Determine category from action type in raw JSON."""
-    return _deterministic_category(json.loads(raw_json))
+    return deterministic_ability_category(json.loads(raw_json))
 
 
 def run_classify(conn, args):

--- a/bin/pf2_seed_creature_types
+++ b/bin/pf2_seed_creature_types
@@ -36,7 +36,10 @@ def _iter_creature_type_names(data_dir):
             try:
                 with open(path) as fp:
                     d = json.load(fp)
-            except (OSError, json.JSONDecodeError):
+            except (OSError, json.JSONDecodeError) as e:
+                # Surface the failure so corrupt parser output is visible,
+                # but keep going so one bad file doesn't abort the whole seed.
+                print(f"warning: skipping {path}: {e}", file=sys.stderr)
                 continue
             sb = d.get("stat_block", {})
             ct = sb.get("creature_type", {})

--- a/bin/pf2_seed_creature_types
+++ b/bin/pf2_seed_creature_types
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Seed the enrichment DB's creature_types table from existing pfsrd2-data output.
+
+One-shot bootstrap so template/family enrichment can route trait additions
+correctly without requiring a full creature re-parse first. After this runs,
+the creature parser keeps the table updated on every run via
+creatures.creature_type_db_pass.
+
+Usage:
+    pf2_seed_creature_types                    # read from $PF2_DATA_DIR
+    pf2_seed_creature_types /path/to/data      # explicit data dir
+"""
+
+import glob
+import json
+import os
+import sys
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(script_dir, ".."))
+
+from pfsrd2.sql.enrichment import (  # noqa: E402
+    fetch_all_creature_types,
+    get_enrichment_db_connection,
+    upsert_creature_type,
+)
+
+
+def _iter_creature_type_names(data_dir):
+    patterns = [
+        os.path.join(data_dir, "monsters", "*", "*.json"),
+        os.path.join(data_dir, "npcs", "*", "*.json"),
+    ]
+    for pattern in patterns:
+        for path in glob.glob(pattern):
+            try:
+                with open(path) as fp:
+                    d = json.load(fp)
+            except (OSError, json.JSONDecodeError):
+                continue
+            sb = d.get("stat_block", {})
+            ct = sb.get("creature_type", {})
+            for name in ct.get("creature_types", []):
+                if isinstance(name, dict):
+                    name = name.get("name")
+                if isinstance(name, str) and name.strip():
+                    yield name.strip()
+
+
+def main():
+    if len(sys.argv) > 1:
+        data_dir = sys.argv[1]
+    else:
+        data_dir = os.environ.get("PF2_DATA_DIR")
+    if not data_dir or not os.path.isdir(data_dir):
+        print(
+            "error: data directory not found. Pass as argument or set $PF2_DATA_DIR.",
+            file=sys.stderr,
+        )
+        return 2
+
+    conn = get_enrichment_db_connection()
+    try:
+        curs = conn.cursor()
+        before = fetch_all_creature_types(curs)
+        seen = set()
+        for name in _iter_creature_type_names(data_dir):
+            if name in seen:
+                continue
+            seen.add(name)
+            upsert_creature_type(curs, name)
+        conn.commit()
+        after = fetch_all_creature_types(curs)
+    finally:
+        conn.close()
+
+    added = sorted(after - before)
+    print(f"Scanned {len(seen)} unique names from {data_dir}")
+    print(f"Creature types in DB: {len(before)} → {len(after)} (+{len(added)})")
+    if added:
+        print("Added:", ", ".join(added))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/pf2_seed_creature_types
+++ b/bin/pf2_seed_creature_types
@@ -34,7 +34,7 @@ def _iter_creature_type_names(data_dir):
     for pattern in patterns:
         for path in glob.glob(pattern):
             try:
-                with open(path) as fp:
+                with open(path, encoding="utf-8") as fp:
                     d = json.load(fp)
             except (OSError, json.JSONDecodeError) as e:
                 # Surface the failure so corrupt parser output is visible,

--- a/pfsrd2/ability_enrichment.py
+++ b/pfsrd2/ability_enrichment.py
@@ -8,6 +8,7 @@ import json
 import re
 
 from pfsrd2.ability_identity import ability_to_raw_json, compute_identity_hash
+from pfsrd2.ability_placement import deterministic_ability_category
 from pfsrd2.enrichment.regex_extractor import ENRICHMENT_VERSION, extract_all
 from pfsrd2.sql import get_db_connection, get_db_path
 from pfsrd2.sql.enrichment import (
@@ -279,24 +280,7 @@ def _is_stage_name(name):
     return bool(re.match(r"^Stage \d+$", name))
 
 
-def _deterministic_category(ability):
-    """Determine ability_category from action type alone.
-
-    Reactions are always reactive. 1/2/3 action abilities are always
-    offensive. Free actions with a trigger are always reactive.
-    Returns the category string, or None if it can't be determined.
-    """
-    action_type = ability.get("action_type")
-    if not isinstance(action_type, dict):
-        return None
-    action_name = action_type.get("name", "")
-    if action_name == "Reaction":
-        return "reactive"
-    if action_name in ("One Action", "Two Actions", "Three Actions"):
-        return "offensive"
-    if action_name == "Free Action" and ability.get("trigger"):
-        return "reactive"
-    return None
+_deterministic_category = deterministic_ability_category
 
 
 def _enrich_abilities(abilities, conn, edition=None):

--- a/pfsrd2/ability_enrichment.py
+++ b/pfsrd2/ability_enrichment.py
@@ -280,9 +280,6 @@ def _is_stage_name(name):
     return bool(re.match(r"^Stage \d+$", name))
 
 
-_deterministic_category = deterministic_ability_category
-
-
 def _enrich_abilities(abilities, conn, edition=None):
     """Core enrichment loop: insert/update records and merge enriched data.
 
@@ -306,7 +303,7 @@ def _enrich_abilities(abilities, conn, edition=None):
                 continue
 
             # Deterministic category from action type — no DB/LLM needed
-            det_cat = _deterministic_category(ability)
+            det_cat = deterministic_ability_category(ability)
             if det_cat:
                 ability["ability_category"] = det_cat
 

--- a/pfsrd2/ability_placement.py
+++ b/pfsrd2/ability_placement.py
@@ -22,6 +22,42 @@ CATEGORY_TARGETS = {
 DEFAULT_TARGET = "$.defense.automatic_abilities"
 
 
+def deterministic_ability_category(ability):
+    """Infer an ability's category from its action_type alone.
+
+    Reactions are always reactive. 1/2/3-action abilities are always
+    offensive. Free actions with a trigger are reactive. Returns the
+    category string, or None if it can't be determined from action_type.
+    """
+    action_type = ability.get("action_type")
+    if not isinstance(action_type, dict):
+        return None
+    action_name = action_type.get("name", "")
+    if action_name == "Reaction":
+        return "reactive"
+    if action_name in ("One Action", "Two Actions", "Three Actions"):
+        return "offensive"
+    if action_name == "Free Action" and ability.get("trigger"):
+        return "reactive"
+    return None
+
+
+def ability_target(ability):
+    """Pick the schema target for an ability using action_type, then DB history.
+
+    Returns a JSONPath string from CATEGORY_TARGETS, or DEFAULT_TARGET if the
+    ability's category can't be determined.
+    """
+    category = deterministic_ability_category(ability)
+    if category:
+        return CATEGORY_TARGETS.get(category, DEFAULT_TARGET)
+    name = ability.get("name")
+    if not name:
+        return DEFAULT_TARGET
+    _, target = lookup_ability_category(name)
+    return target
+
+
 def lookup_ability_category(ability_name, conn=None):
     """Look up the most common category for an ability by name.
 

--- a/pfsrd2/ability_placement.py
+++ b/pfsrd2/ability_placement.py
@@ -46,14 +46,14 @@ def ability_target(ability):
     """Pick the schema target for an ability using action_type, then DB history.
 
     Returns a JSONPath string from CATEGORY_TARGETS, or DEFAULT_TARGET if the
-    ability's category can't be determined.
+    ability's category can't be determined. A nameless ability is a parser
+    bug — assert rather than silently return a default.
     """
     category = deterministic_ability_category(ability)
     if category:
         return CATEGORY_TARGETS.get(category, DEFAULT_TARGET)
     name = ability.get("name")
-    if not name:
-        return DEFAULT_TARGET
+    assert name, f"Ability missing required 'name' field: {ability!r}"
     _, target = lookup_ability_category(name)
     return target
 

--- a/pfsrd2/creatures.py
+++ b/pfsrd2/creatures.py
@@ -640,6 +640,7 @@ def creature_type_db_pass(struct):
         curs = conn.cursor()
         for name in names:
             assert isinstance(name, str) and name, f"Invalid creature_type entry: {name!r}"
+            assert name == name.strip(), f"creature_type has leading/trailing whitespace: {name!r}"
             upsert_creature_type(curs, name)
         conn.commit()
     finally:

--- a/pfsrd2/creatures.py
+++ b/pfsrd2/creatures.py
@@ -12,6 +12,7 @@ from pfsrd2.action import build_action_type, extract_action_type
 from pfsrd2.license import license_consolidation_pass, license_pass
 from pfsrd2.schema import validate_against_schema
 from pfsrd2.sql import get_db_connection, get_db_path
+from pfsrd2.sql.enrichment import get_enrichment_db_connection, upsert_creature_type
 from pfsrd2.sql.monster_families import (
     fetch_monster_family_by_aonid,
     fetch_monster_family_by_link,
@@ -150,6 +151,7 @@ def parse_creature(filename, options):
     restructure_pass(struct, "stat_block", find_stat_block)
     recall_knowledge_pass(struct)
     trait_pass(struct)
+    creature_type_db_pass(struct)
     section_pass(struct)
     monster_family_db_pass(struct)
     universal_trait_db_pass(struct, pre_process=_creature_trait_pre_process)
@@ -621,6 +623,26 @@ def trait_pass(struct):
         raise AssertionError("Has no creature types")
     if "size" not in sb["creature_type"]:
         raise AssertionError("Has no size")
+
+
+def creature_type_db_pass(struct):
+    """Register every creature_type name this creature has into the enrichment DB.
+
+    Makes the DB the source of truth for 'is this name a creature type?' —
+    used by template/family enrichment to route trait additions correctly.
+    """
+    sb = struct["stat_block"]
+    names = sb.get("creature_type", {}).get("creature_types", [])
+    if not names:
+        return
+    conn = get_enrichment_db_connection()
+    try:
+        curs = conn.cursor()
+        for name in names:
+            upsert_creature_type(curs, name)
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def creature_stat_block_pass(struct):

--- a/pfsrd2/creatures.py
+++ b/pfsrd2/creatures.py
@@ -639,6 +639,7 @@ def creature_type_db_pass(struct):
     try:
         curs = conn.cursor()
         for name in names:
+            assert isinstance(name, str) and name, f"Invalid creature_type entry: {name!r}"
             upsert_creature_type(curs, name)
         conn.commit()
     finally:

--- a/pfsrd2/enrichment/change_extractor.py
+++ b/pfsrd2/enrichment/change_extractor.py
@@ -9,6 +9,9 @@ import json
 import re
 import sys
 
+from pfsrd2.ability_placement import CATEGORY_TARGETS, ability_target
+from pfsrd2.sql.enrichment import fetch_all_creature_types, get_enrichment_db_connection
+
 ENRICHMENT_VERSION = 19
 
 # HTML says "land Speed" but creature data uses "walk" for walking speed
@@ -27,17 +30,29 @@ def reset_creature_types_cache():
 
 
 def _get_creature_types():
-    """Return the set of known creature types from the enrichment DB."""
+    """Return the lowercased set of known creature types from the enrichment DB.
+
+    Lowercased to mirror the table's COLLATE NOCASE and to give case-insensitive
+    membership testing in Python. Emits a warning to stderr if the table is
+    empty — this means the seed script never ran or the DB was wiped, and
+    trait routing will regress to $.traits-only for every name. Caller must
+    run bin/pf2_seed_creature_types or a full creature parse to populate.
+    """
     global _CREATURE_TYPES_CACHE
     if _CREATURE_TYPES_CACHE is not None:
         return _CREATURE_TYPES_CACHE
-    from pfsrd2.sql.enrichment import fetch_all_creature_types, get_enrichment_db_connection
-
     conn = get_enrichment_db_connection()
     try:
-        _CREATURE_TYPES_CACHE = fetch_all_creature_types(conn.cursor())
+        names = fetch_all_creature_types(conn.cursor())
     finally:
         conn.close()
+    _CREATURE_TYPES_CACHE = frozenset(n.lower() for n in names)
+    if not _CREATURE_TYPES_CACHE:
+        sys.stderr.write(
+            "WARNING: creature_types table is empty — template/family trait "
+            "routing will send every name to $.traits. "
+            "Run bin/pf2_seed_creature_types or the creature parser to populate.\n"
+        )
     return _CREATURE_TYPES_CACHE
 
 
@@ -46,8 +61,9 @@ def _trait_target(name):
 
     Creature types (per the enrichment DB, populated by the creature parser)
     go to $.creature_type.creature_types. All other traits go to $.traits.
+    Match is case-insensitive.
     """
-    if name in _get_creature_types():
+    if name.lower() in _get_creature_types():
         return "$.creature_type.creature_types"
     return "$.traits"
 
@@ -85,9 +101,7 @@ def enrich_change(raw_json_str, source_name):
 
     links = change.get("links")
     abilities = change.get("abilities")
-    effects = _build_effects(
-        text, category, source_name, adjustments, links, abilities=abilities
-    )
+    effects = _build_effects(text, category, source_name, adjustments, links, abilities=abilities)
     if effects:
         enriched["effects"] = effects
 
@@ -245,43 +259,7 @@ def _build_effects(text, category, source_name, adjustments=None, links=None, ab
     return []
 
 
-_ABILITIES_FALLBACK_TARGET = "$.defense.automatic_abilities"
-
-
-def _deterministic_ability_category(ability):
-    """Infer ability_category from the ability's action_type alone.
-
-    Mirrors pfsrd2.ability_enrichment._deterministic_category so enrichment
-    can route template-added abilities without needing the DB.
-    """
-    action_type = ability.get("action_type")
-    if not isinstance(action_type, dict):
-        return None
-    action_name = action_type.get("name", "")
-    if action_name == "Reaction":
-        return "reactive"
-    if action_name in ("One Action", "Two Actions", "Three Actions"):
-        return "offensive"
-    if action_name == "Free Action" and ability.get("trigger"):
-        return "reactive"
-    return None
-
-
-def _ability_target(ability):
-    """Pick the schema target for an ability using action_type, then DB history."""
-    from pfsrd2.ability_placement import CATEGORY_TARGETS, lookup_ability_category
-
-    category = _deterministic_ability_category(ability)
-    if category:
-        return CATEGORY_TARGETS.get(category, _ABILITIES_FALLBACK_TARGET)
-    name = ability.get("name")
-    if not name:
-        return _ABILITIES_FALLBACK_TARGET
-    try:
-        _, target = lookup_ability_category(name)
-    except Exception:
-        target = _ABILITIES_FALLBACK_TARGET
-    return target
+_ABILITIES_FALLBACK_TARGET = CATEGORY_TARGETS["automatic"]
 
 
 def _build_ability_effects(abilities):
@@ -301,9 +279,8 @@ def _build_ability_effects(abilities):
     effects = []
     for ability in abilities:
         name = ability.get("name")
-        if not name:
-            continue
-        target = _ability_target(ability)
+        assert name, f"Ability missing required 'name' field: {ability!r}"
+        target = ability_target(ability)
         escaped = name.replace("\\", "\\\\").replace("'", "\\'")
         effects.append(
             {

--- a/pfsrd2/enrichment/change_extractor.py
+++ b/pfsrd2/enrichment/change_extractor.py
@@ -9,42 +9,45 @@ import json
 import re
 import sys
 
-ENRICHMENT_VERSION = 17
+ENRICHMENT_VERSION = 19
 
 # HTML says "land Speed" but creature data uses "walk" for walking speed
 _MOVEMENT_TYPE_NORMALIZE = {"land": "walk"}
 
-# PF2e creature types — traits that represent fundamental creature classification.
-# These go to $.creature_type.creature_types. All other traits go to $.traits.
-_CREATURE_TYPES = {
-    "Aberration",
-    "Animal",
-    "Astral",
-    "Beast",
-    "Celestial",
-    "Construct",
-    "Dragon",
-    "Dream",
-    "Elemental",
-    "Ethereal",
-    "Fey",
-    "Fiend",
-    "Fungus",
-    "Giant",
-    "Humanoid",
-    "Monitor",
-    "Ooze",
-    "Petitioner",
-    "Plant",
-    "Spirit",
-    "Time",
-    "Undead",
-}
+# Cache of known creature types loaded from the enrichment DB.
+# Populated lazily on first call; cleared by reset_creature_types_cache() for tests.
+_CREATURE_TYPES_CACHE = None
+
+
+def reset_creature_types_cache():
+    """Drop the cached creature-type set. Used by tests and by long-running
+    enrichment processes that want to pick up newly-registered types."""
+    global _CREATURE_TYPES_CACHE
+    _CREATURE_TYPES_CACHE = None
+
+
+def _get_creature_types():
+    """Return the set of known creature types from the enrichment DB."""
+    global _CREATURE_TYPES_CACHE
+    if _CREATURE_TYPES_CACHE is not None:
+        return _CREATURE_TYPES_CACHE
+    from pfsrd2.sql.enrichment import fetch_all_creature_types, get_enrichment_db_connection
+
+    conn = get_enrichment_db_connection()
+    try:
+        _CREATURE_TYPES_CACHE = fetch_all_creature_types(conn.cursor())
+    finally:
+        conn.close()
+    return _CREATURE_TYPES_CACHE
 
 
 def _trait_target(name):
-    """Return the correct JSON path target for a trait name."""
-    if name in _CREATURE_TYPES:
+    """Return the correct JSON path target for a trait name.
+
+    Creature types (per the enrichment DB, populated by the creature parser)
+    go to $.creature_type.creature_types. All other traits go to $.traits.
+    """
+    if name in _get_creature_types():
         return "$.creature_type.creature_types"
     return "$.traits"
 
@@ -81,7 +84,10 @@ def enrich_change(raw_json_str, source_name):
     }
 
     links = change.get("links")
-    effects = _build_effects(text, category, source_name, adjustments, links)
+    abilities = change.get("abilities")
+    effects = _build_effects(
+        text, category, source_name, adjustments, links, abilities=abilities
+    )
     if effects:
         enriched["effects"] = effects
 
@@ -192,16 +198,10 @@ def _categorize_change_text(text):
     return "unknown"
 
 
-def _build_effects(text, category, source_name, adjustments=None, links=None):
+def _build_effects(text, category, source_name, adjustments=None, links=None, abilities=None):
     """Build effects for a categorized change."""
     if category == "abilities":
-        return [
-            {
-                "target": "$.defense.automatic_abilities",
-                "operation": "add_items",
-                "source": "$.changes[*].abilities",
-            }
-        ]
+        return _build_ability_effects(abilities)
     elif category == "immunities":
         return _build_immunity_effects(text)
     elif category == "languages":
@@ -243,6 +243,76 @@ def _build_effects(text, category, source_name, adjustments=None, links=None):
             }
         ]
     return []
+
+
+_ABILITIES_FALLBACK_TARGET = "$.defense.automatic_abilities"
+
+
+def _deterministic_ability_category(ability):
+    """Infer ability_category from the ability's action_type alone.
+
+    Mirrors pfsrd2.ability_enrichment._deterministic_category so enrichment
+    can route template-added abilities without needing the DB.
+    """
+    action_type = ability.get("action_type")
+    if not isinstance(action_type, dict):
+        return None
+    action_name = action_type.get("name", "")
+    if action_name == "Reaction":
+        return "reactive"
+    if action_name in ("One Action", "Two Actions", "Three Actions"):
+        return "offensive"
+    if action_name == "Free Action" and ability.get("trigger"):
+        return "reactive"
+    return None
+
+
+def _ability_target(ability):
+    """Pick the schema target for an ability using action_type, then DB history."""
+    from pfsrd2.ability_placement import CATEGORY_TARGETS, lookup_ability_category
+
+    category = _deterministic_ability_category(ability)
+    if category:
+        return CATEGORY_TARGETS.get(category, _ABILITIES_FALLBACK_TARGET)
+    name = ability.get("name")
+    if not name:
+        return _ABILITIES_FALLBACK_TARGET
+    try:
+        _, target = lookup_ability_category(name)
+    except Exception:
+        target = _ABILITIES_FALLBACK_TARGET
+    return target
+
+
+def _build_ability_effects(abilities):
+    """Emit one effect per ability, routed by category.
+
+    Without parsed abilities we keep the legacy blanket target so callers
+    that only have the raw text still get some placement.
+    """
+    if not abilities:
+        return [
+            {
+                "target": _ABILITIES_FALLBACK_TARGET,
+                "operation": "add_items",
+                "source": "$.changes[*].abilities",
+            }
+        ]
+    effects = []
+    for ability in abilities:
+        name = ability.get("name")
+        if not name:
+            continue
+        target = _ability_target(ability)
+        escaped = name.replace("\\", "\\\\").replace("'", "\\'")
+        effects.append(
+            {
+                "target": target,
+                "operation": "add_items",
+                "source": f"$.changes[*].abilities[?(@.name=='{escaped}')]",
+            }
+        )
+    return effects
 
 
 def _extract_names_from_text(text, after_marker):
@@ -710,6 +780,13 @@ def _build_combat_stat_effects(text):
                 "value": val,
             }
         )
+        effects.append(
+            {
+                "target": "$.offense.offensive_actions[*].spells.spell_attack",
+                "operation": "adjustment",
+                "value": val,
+            }
+        )
     if "dc" in t:
         effects.append(
             {
@@ -802,6 +879,15 @@ def _build_damage_effects(text, source_name=""):
                     "target": "$.offense.offensive_actions[*].ability.damage",
                     "operation": "add_item",
                     "item": limited_item,
+                }
+            )
+            sign = "+" if limited_val >= 0 else ""
+            spell_note = f"{sign}{limited_val} damage ({limited_notes})"
+            effects.append(
+                {
+                    "target": "$.offense.offensive_actions[*].spells.notes",
+                    "operation": "add_item",
+                    "item": spell_note,
                 }
             )
         return effects

--- a/pfsrd2/sql/enrichment/__init__.py
+++ b/pfsrd2/sql/enrichment/__init__.py
@@ -181,6 +181,24 @@ def _create_db_v_6(conn, curs, ver):
     return ver
 
 
+def _create_db_v_7(conn, curs, ver):
+    """Version 7: Rebuild creature_types with COLLATE NOCASE on name.
+
+    The v6 table stored names case-sensitively; trait links in template
+    text sometimes lowercase names, causing misrouting. Rebuild the table
+    with case-insensitive uniqueness and re-seed via bin/pf2_seed_creature_types
+    (or a creature parse) after migration.
+    """
+    if ver >= 7:
+        return ver
+    ver = 7
+    curs.execute("DROP TABLE IF EXISTS creature_types")
+    create_creature_types_table(curs)
+    _set_version(curs, ver)
+    conn.commit()
+    return ver
+
+
 # --- Connection ---
 
 
@@ -205,6 +223,7 @@ def get_enrichment_db_connection(db_path=None):
         ver = _create_db_v_4(conn, curs, ver)
         ver = _create_db_v_5(conn, curs, ver)
         ver = _create_db_v_6(conn, curs, ver)
+        ver = _create_db_v_7(conn, curs, ver)
     finally:
         curs.close()
     conn.row_factory = _dict_factory

--- a/pfsrd2/sql/enrichment/__init__.py
+++ b/pfsrd2/sql/enrichment/__init__.py
@@ -16,6 +16,7 @@ from pfsrd2.sql.enrichment.queries import (  # noqa: F401
     fetch_abilities_for_creature,
     fetch_ability_by_hash,
     fetch_ability_by_id,
+    fetch_all_creature_types,
     fetch_change_by_hash,
     fetch_changes_for_source,
     fetch_changes_needing_enrichment,
@@ -40,6 +41,7 @@ from pfsrd2.sql.enrichment.queries import (  # noqa: F401
     update_enriched_json,
     update_identity_hash,
     update_is_uma,
+    upsert_creature_type,
 )
 from pfsrd2.sql.enrichment.tables import (
     create_ability_creature_links_index,
@@ -48,6 +50,7 @@ from pfsrd2.sql.enrichment.tables import (
     create_ability_records_table,
     create_change_records_index,
     create_change_records_table,
+    create_creature_types_table,
 )
 
 DB_NAME = "enrichment.db"
@@ -162,6 +165,22 @@ def _create_db_v_5(conn, curs, ver):
     return ver
 
 
+def _create_db_v_6(conn, curs, ver):
+    """Version 6: Creature types table.
+
+    Source of truth for "is this name a creature type?" — populated by the
+    creature parser as it encounters types, and queried by the template/family
+    enrichment code to decide trait vs creature_type routing.
+    """
+    if ver >= 6:
+        return ver
+    ver = 6
+    create_creature_types_table(curs)
+    _set_version(curs, ver)
+    conn.commit()
+    return ver
+
+
 # --- Connection ---
 
 
@@ -185,6 +204,7 @@ def get_enrichment_db_connection(db_path=None):
         ver = _create_db_v_3(conn, curs, ver)
         ver = _create_db_v_4(conn, curs, ver)
         ver = _create_db_v_5(conn, curs, ver)
+        ver = _create_db_v_6(conn, curs, ver)
     finally:
         curs.close()
     conn.row_factory = _dict_factory

--- a/pfsrd2/sql/enrichment/__init__.py
+++ b/pfsrd2/sql/enrichment/__init__.py
@@ -166,33 +166,17 @@ def _create_db_v_5(conn, curs, ver):
 
 
 def _create_db_v_6(conn, curs, ver):
-    """Version 6: Creature types table.
+    """Version 6: Creature types table (case-insensitive name).
 
     Source of truth for "is this name a creature type?" — populated by the
     creature parser as it encounters types, and queried by the template/family
-    enrichment code to decide trait vs creature_type routing.
+    enrichment code to decide trait vs creature_type routing. The name column
+    is COLLATE NOCASE so trait links that lowercase names still match the
+    canonical title-cased form stored by the creature parser.
     """
     if ver >= 6:
         return ver
     ver = 6
-    create_creature_types_table(curs)
-    _set_version(curs, ver)
-    conn.commit()
-    return ver
-
-
-def _create_db_v_7(conn, curs, ver):
-    """Version 7: Rebuild creature_types with COLLATE NOCASE on name.
-
-    The v6 table stored names case-sensitively; trait links in template
-    text sometimes lowercase names, causing misrouting. Rebuild the table
-    with case-insensitive uniqueness and re-seed via bin/pf2_seed_creature_types
-    (or a creature parse) after migration.
-    """
-    if ver >= 7:
-        return ver
-    ver = 7
-    curs.execute("DROP TABLE IF EXISTS creature_types")
     create_creature_types_table(curs)
     _set_version(curs, ver)
     conn.commit()
@@ -223,7 +207,6 @@ def get_enrichment_db_connection(db_path=None):
         ver = _create_db_v_4(conn, curs, ver)
         ver = _create_db_v_5(conn, curs, ver)
         ver = _create_db_v_6(conn, curs, ver)
-        ver = _create_db_v_7(conn, curs, ver)
     finally:
         curs.close()
     conn.row_factory = _dict_factory

--- a/pfsrd2/sql/enrichment/queries.py
+++ b/pfsrd2/sql/enrichment/queries.py
@@ -422,3 +422,18 @@ def fetch_majority_category_for_name(curs, name):
         return None
     total = sum(r["cnt"] for r in rows)
     return rows[0]["ability_category"], rows[0]["cnt"], total
+
+
+# --- Creature types ---
+
+
+def upsert_creature_type(curs, name):
+    """Insert a creature type name if not already present. Idempotent."""
+    sql = "INSERT OR IGNORE INTO creature_types (name, created_at) VALUES (?, ?)"
+    curs.execute(sql, (name, _now()))
+
+
+def fetch_all_creature_types(curs):
+    """Return the set of known creature type names."""
+    curs.execute("SELECT name FROM creature_types")
+    return {row["name"] for row in curs.fetchall()}

--- a/pfsrd2/sql/enrichment/tables.py
+++ b/pfsrd2/sql/enrichment/tables.py
@@ -103,11 +103,14 @@ def create_change_records_index(curs):
 
 
 def create_creature_types_table(curs):
+    # COLLATE NOCASE so lookups and uniqueness are case-insensitive — template
+    # link text may lowercase trait names while the canonical creature data
+    # uses title case.
     sql = "\n".join(
         [
             "CREATE TABLE creature_types (",
             "  creature_type_id INTEGER PRIMARY KEY,",
-            "  name TEXT NOT NULL UNIQUE,",
+            "  name TEXT NOT NULL UNIQUE COLLATE NOCASE,",
             "  created_at TEXT NOT NULL",
             ")",
         ]

--- a/pfsrd2/sql/enrichment/tables.py
+++ b/pfsrd2/sql/enrichment/tables.py
@@ -97,3 +97,19 @@ def create_change_records_index(curs):
         "CREATE INDEX change_records_enrichment_version ON change_records (enrichment_version)"
     )
     curs.execute("CREATE INDEX change_records_needs_review ON change_records (needs_review)")
+
+
+# --- Creature types (source of truth for trait routing) ---
+
+
+def create_creature_types_table(curs):
+    sql = "\n".join(
+        [
+            "CREATE TABLE creature_types (",
+            "  creature_type_id INTEGER PRIMARY KEY,",
+            "  name TEXT NOT NULL UNIQUE,",
+            "  created_at TEXT NOT NULL",
+            ")",
+        ]
+    )
+    curs.execute(sql)

--- a/tests/test_change_extractor.py
+++ b/tests/test_change_extractor.py
@@ -1,6 +1,10 @@
 import json
 
+import pytest
+
+from pfsrd2 import ability_placement
 from pfsrd2.enrichment.change_extractor import (
+    _build_ability_effects,
     _build_combat_stat_effects,
     _build_damage_effects,
     _build_hit_points_effects,
@@ -440,6 +444,92 @@ class TestBuildDamageEffects:
         ]
         assert len(notes_effects) == 1
         assert notes_effects[0]["item"] == "-4 damage (Weak, limited use)"
+
+
+class TestBuildAbilityEffects:
+    def test_empty_abilities_falls_back_to_blanket_target(self):
+        effects = _build_ability_effects(None)
+        assert effects == [
+            {
+                "target": "$.defense.automatic_abilities",
+                "operation": "add_items",
+                "source": "$.changes[*].abilities",
+            }
+        ]
+
+    def test_empty_list_falls_back(self):
+        assert _build_ability_effects([]) == _build_ability_effects(None)
+
+    def test_routes_per_ability_by_action_type(self):
+        """One-action → offensive, reaction → reactive, three actions → offensive."""
+        abilities = [
+            {"name": "A", "action_type": {"name": "One Action"}},
+            {"name": "B", "action_type": {"name": "Reaction"}},
+            {"name": "C", "action_type": {"name": "Three Actions"}},
+        ]
+        effects = _build_ability_effects(abilities)
+        assert len(effects) == 3
+        by_name = {e["source"].split("'")[1]: e["target"] for e in effects}
+        assert by_name["A"] == "$.offense.offensive_actions"
+        assert by_name["B"] == "$.defense.reactive_abilities"
+        assert by_name["C"] == "$.offense.offensive_actions"
+
+    def test_escapes_quotes_and_backslashes_in_source(self):
+        abilities = [{"name": "Bob's \\Backslash", "action_type": {"name": "Reaction"}}]
+        effects = _build_ability_effects(abilities)
+        assert len(effects) == 1
+        # Single-quote escaped and backslash escaped so JSONPath stays valid
+        assert r"Bob\'s \\Backslash" in effects[0]["source"]
+        assert effects[0]["target"] == "$.defense.reactive_abilities"
+
+    def test_asserts_on_unnamed_ability(self):
+        """Strategic fragility — parser bug should not be swallowed."""
+        abilities = [{"action_type": {"name": "One Action"}}]
+        with pytest.raises(AssertionError):
+            _build_ability_effects(abilities)
+
+
+class TestDeterministicAbilityCategory:
+    def test_reaction(self):
+        assert (
+            ability_placement.deterministic_ability_category({"action_type": {"name": "Reaction"}})
+            == "reactive"
+        )
+
+    def test_one_two_three_action_offensive(self):
+        for n in ("One Action", "Two Actions", "Three Actions"):
+            assert (
+                ability_placement.deterministic_ability_category({"action_type": {"name": n}})
+                == "offensive"
+            )
+
+    def test_free_action_with_trigger_is_reactive(self):
+        ability = {"action_type": {"name": "Free Action"}, "trigger": "something"}
+        assert ability_placement.deterministic_ability_category(ability) == "reactive"
+
+    def test_free_action_without_trigger_is_none(self):
+        assert (
+            ability_placement.deterministic_ability_category(
+                {"action_type": {"name": "Free Action"}}
+            )
+            is None
+        )
+
+    def test_missing_or_non_dict_action_type(self):
+        assert ability_placement.deterministic_ability_category({}) is None
+        assert ability_placement.deterministic_ability_category({"action_type": None}) is None
+        assert (
+            ability_placement.deterministic_ability_category({"action_type": "One Action"}) is None
+        )
+
+
+class TestAbilityTarget:
+    def test_uses_deterministic_category_when_available(self):
+        ability = {"name": "Anything", "action_type": {"name": "Reaction"}}
+        assert ability_placement.ability_target(ability) == "$.defense.reactive_abilities"
+
+    def test_missing_name_returns_default(self):
+        assert ability_placement.ability_target({}) == ability_placement.DEFAULT_TARGET
 
 
 class TestBuildSpeedEffectsRemoveAll:

--- a/tests/test_change_extractor.py
+++ b/tests/test_change_extractor.py
@@ -528,8 +528,9 @@ class TestAbilityTarget:
         ability = {"name": "Anything", "action_type": {"name": "Reaction"}}
         assert ability_placement.ability_target(ability) == "$.defense.reactive_abilities"
 
-    def test_missing_name_returns_default(self):
-        assert ability_placement.ability_target({}) == ability_placement.DEFAULT_TARGET
+    def test_missing_name_asserts(self):
+        with pytest.raises(AssertionError):
+            ability_placement.ability_target({})
 
 
 class TestBuildSpeedEffectsRemoveAll:

--- a/tests/test_change_extractor.py
+++ b/tests/test_change_extractor.py
@@ -316,6 +316,14 @@ class TestBuildCombatStatEffects:
         for eff in effects:
             assert eff["value"] == -2
 
+    def test_attack_emits_spell_attack_target(self):
+        """pfsrd2-j7ko: 'attack modifiers' must bump strike attack AND spell attack."""
+        text = "Increase attack modifiers by 2."
+        effects = _build_combat_stat_effects(text)
+        targets = [e["target"] for e in effects]
+        assert "$.offense.offensive_actions[*].attack.bonus.bonuses" in targets
+        assert "$.offense.offensive_actions[*].spells.spell_attack" in targets
+
 
 class TestBuildHitPointsEffects:
     def test_with_adjustments(self):
@@ -398,6 +406,40 @@ class TestBuildDamageEffects:
         effects = _build_damage_effects(text, "Ghost")
         magical = [e for e in effects if e.get("operation") == "add_item"]
         assert len(magical) == 0
+
+    def test_limited_use_emits_spell_notes_annotation(self):
+        """pfsrd2-97fv: 'increase damage by N instead' (limited use) annotates spells.notes.
+
+        Spells have no integer damage field — individual spells may or may not deal
+        damage — so the +N instead bump is communicated as a string note.
+        """
+        text = (
+            "Increase the damage of its Strikes and other offensive abilities by 2. "
+            "If the creature has limits on how many times or how often it can use an ability "
+            "(such as a spellcaster's spells or a dragon's Breath Weapon), "
+            "increase the damage by 4 instead."
+        )
+        effects = _build_damage_effects(text, "Elite")
+        notes_effects = [
+            e for e in effects if e.get("target") == "$.offense.offensive_actions[*].spells.notes"
+        ]
+        assert len(notes_effects) == 1
+        assert notes_effects[0]["operation"] == "add_item"
+        assert notes_effects[0]["item"] == "+4 damage (Elite, limited use)"
+
+    def test_limited_use_negative_spell_notes(self):
+        """Weak template: -2 base, -4 limited use → notes string uses bare '-4'."""
+        text = (
+            "Decrease the damage of its Strikes and other offensive abilities by 2. "
+            "If the creature has limits on how many times or how often it can use an ability, "
+            "decrease the damage by 4 instead."
+        )
+        effects = _build_damage_effects(text, "Weak")
+        notes_effects = [
+            e for e in effects if e.get("target") == "$.offense.offensive_actions[*].spells.notes"
+        ]
+        assert len(notes_effects) == 1
+        assert notes_effects[0]["item"] == "-4 damage (Weak, limited use)"
 
 
 class TestBuildSpeedEffectsRemoveAll:

--- a/tests/test_creature_types_db.py
+++ b/tests/test_creature_types_db.py
@@ -1,0 +1,80 @@
+"""Tests for the creature_types enrichment table and trait-target routing."""
+
+import pytest
+
+from pfsrd2.enrichment import change_extractor
+from pfsrd2.enrichment.change_extractor import _trait_target
+from pfsrd2.sql.enrichment import (
+    fetch_all_creature_types,
+    get_enrichment_db_connection,
+    upsert_creature_type,
+)
+
+
+class _KeepOpenConn:
+    """Passthrough wrapper that ignores close() so multiple _trait_target calls
+    can share a single in-memory sqlite connection."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def db_with_types(monkeypatch):
+    """In-memory enrichment DB seeded with a few creature types.
+
+    Patches change_extractor's lazy DB opener to use the in-memory conn
+    and resets the module cache between tests.
+    """
+    conn = get_enrichment_db_connection(db_path=":memory:")
+    curs = conn.cursor()
+    for name in ("Undead", "Vampire", "Aquatic"):
+        upsert_creature_type(curs, name)
+    conn.commit()
+    wrapper = _KeepOpenConn(conn)
+
+    import pfsrd2.sql.enrichment as enrichment_pkg
+
+    monkeypatch.setattr(enrichment_pkg, "get_enrichment_db_connection", lambda: wrapper)
+    change_extractor.reset_creature_types_cache()
+    yield conn
+    change_extractor.reset_creature_types_cache()
+    conn.close()
+
+
+class TestCreatureTypesTable:
+    def test_upsert_is_idempotent(self, db_with_types):
+        curs = db_with_types.cursor()
+        upsert_creature_type(curs, "Vampire")  # already there
+        upsert_creature_type(curs, "Skeleton")  # new
+        db_with_types.commit()
+        names = fetch_all_creature_types(curs)
+        assert "Vampire" in names
+        assert "Skeleton" in names
+        curs.execute("SELECT COUNT(*) as c FROM creature_types WHERE name='Vampire'")
+        assert curs.fetchone()["c"] == 1
+
+
+class TestTraitTargetDBLookup:
+    def test_known_creature_type_routes_to_creature_types(self, db_with_types):
+        assert _trait_target("Undead") == "$.creature_type.creature_types"
+        assert _trait_target("Vampire") == "$.creature_type.creature_types"
+        assert _trait_target("Aquatic") == "$.creature_type.creature_types"
+
+    def test_unknown_name_routes_to_traits(self, db_with_types):
+        assert _trait_target("Rare") == "$.traits"
+        assert _trait_target("Uncommon") == "$.traits"
+        assert _trait_target("SomeNewAncestry") == "$.traits"
+
+    def test_cache_refreshes_after_reset(self, db_with_types):
+        assert _trait_target("Newtype") == "$.traits"
+        upsert_creature_type(db_with_types.cursor(), "Newtype")
+        db_with_types.commit()
+        change_extractor.reset_creature_types_cache()
+        assert _trait_target("Newtype") == "$.creature_type.creature_types"

--- a/tests/test_creature_types_db.py
+++ b/tests/test_creature_types_db.py
@@ -39,9 +39,7 @@ def db_with_types(monkeypatch):
     conn.commit()
     wrapper = _KeepOpenConn(conn)
 
-    import pfsrd2.sql.enrichment as enrichment_pkg
-
-    monkeypatch.setattr(enrichment_pkg, "get_enrichment_db_connection", lambda: wrapper)
+    monkeypatch.setattr(change_extractor, "get_enrichment_db_connection", lambda: wrapper)
     change_extractor.reset_creature_types_cache()
     yield conn
     change_extractor.reset_creature_types_cache()
@@ -78,3 +76,60 @@ class TestTraitTargetDBLookup:
         db_with_types.commit()
         change_extractor.reset_creature_types_cache()
         assert _trait_target("Newtype") == "$.creature_type.creature_types"
+
+    def test_case_insensitive_lookup(self, db_with_types):
+        """COLLATE NOCASE on the DB column + lowercased cache lets a change
+        referring to 'undead' route the same as the canonical 'Undead'."""
+        assert _trait_target("undead") == "$.creature_type.creature_types"
+        assert _trait_target("VAMPIRE") == "$.creature_type.creature_types"
+
+
+class TestCreatureTypeDBPass:
+    def test_upserts_every_creature_type(self, db_with_types, monkeypatch):
+        from pfsrd2 import creatures
+
+        monkeypatch.setattr(
+            creatures, "get_enrichment_db_connection", lambda: _KeepOpenConn(db_with_types)
+        )
+        struct = {
+            "stat_block": {
+                "creature_type": {"creature_types": ["Human", "Humanoid"]},
+            }
+        }
+        creatures.creature_type_db_pass(struct)
+        names = fetch_all_creature_types(db_with_types.cursor())
+        assert "Human" in names
+        assert "Humanoid" in names
+
+    def test_no_creature_types_is_noop(self, db_with_types, monkeypatch):
+        from pfsrd2 import creatures
+
+        called = []
+        monkeypatch.setattr(
+            creatures,
+            "get_enrichment_db_connection",
+            lambda: (called.append(True) or _KeepOpenConn(db_with_types)),
+        )
+        creatures.creature_type_db_pass({"stat_block": {"creature_type": {}}})
+        creatures.creature_type_db_pass({"stat_block": {"creature_type": {"creature_types": []}}})
+        assert called == []  # short-circuits before opening a connection
+
+    def test_asserts_on_empty_string(self, db_with_types, monkeypatch):
+        from pfsrd2 import creatures
+
+        monkeypatch.setattr(
+            creatures, "get_enrichment_db_connection", lambda: _KeepOpenConn(db_with_types)
+        )
+        struct = {"stat_block": {"creature_type": {"creature_types": [""]}}}
+        with pytest.raises(AssertionError):
+            creatures.creature_type_db_pass(struct)
+
+    def test_asserts_on_non_string(self, db_with_types, monkeypatch):
+        from pfsrd2 import creatures
+
+        monkeypatch.setattr(
+            creatures, "get_enrichment_db_connection", lambda: _KeepOpenConn(db_with_types)
+        )
+        struct = {"stat_block": {"creature_type": {"creature_types": [None]}}}
+        with pytest.raises(AssertionError):
+            creatures.creature_type_db_pass(struct)

--- a/tests/test_creature_types_db.py
+++ b/tests/test_creature_types_db.py
@@ -84,6 +84,29 @@ class TestTraitTargetDBLookup:
         assert _trait_target("VAMPIRE") == "$.creature_type.creature_types"
 
 
+class TestEmptyTableWarning:
+    def test_empty_table_warns_to_stderr_and_returns_empty_set(self, monkeypatch, capsys):
+        """If the table exists but has no rows, _get_creature_types must emit
+        a stderr warning and return an empty set so trait routing sends
+        everything to $.traits."""
+        conn = get_enrichment_db_connection(db_path=":memory:")
+        # Don't seed anything — table is empty
+        wrapper = _KeepOpenConn(conn)
+        monkeypatch.setattr(change_extractor, "get_enrichment_db_connection", lambda: wrapper)
+        change_extractor.reset_creature_types_cache()
+        try:
+            result = change_extractor._get_creature_types()
+            assert result == frozenset()
+            err = capsys.readouterr().err
+            assert "creature_types table is empty" in err
+            assert "pf2_seed_creature_types" in err
+            # Confirm routing falls back to $.traits for any name
+            assert _trait_target("Undead") == "$.traits"
+        finally:
+            change_extractor.reset_creature_types_cache()
+            conn.close()
+
+
 class TestCreatureTypeDBPass:
     def test_upserts_every_creature_type(self, db_with_types, monkeypatch):
         from pfsrd2 import creatures
@@ -132,4 +155,14 @@ class TestCreatureTypeDBPass:
         )
         struct = {"stat_block": {"creature_type": {"creature_types": [None]}}}
         with pytest.raises(AssertionError):
+            creatures.creature_type_db_pass(struct)
+
+    def test_asserts_on_whitespace(self, db_with_types, monkeypatch):
+        from pfsrd2 import creatures
+
+        monkeypatch.setattr(
+            creatures, "get_enrichment_db_connection", lambda: _KeepOpenConn(db_with_types)
+        )
+        struct = {"stat_block": {"creature_type": {"creature_types": [" Undead "]}}}
+        with pytest.raises(AssertionError, match="whitespace"):
             creatures.creature_type_db_pass(struct)

--- a/tests/test_deterministic_category.py
+++ b/tests/test_deterministic_category.py
@@ -1,6 +1,6 @@
-"""Tests for _deterministic_category in ability_enrichment.py."""
+"""Tests for deterministic_ability_category in ability_placement.py."""
 
-from pfsrd2.ability_enrichment import _deterministic_category
+from pfsrd2.ability_placement import deterministic_ability_category
 
 
 class TestDeterministicCategory:
@@ -12,7 +12,7 @@ class TestDeterministicCategory:
                 "name": "Reaction",
             }
         }
-        assert _deterministic_category(ability) == "reactive"
+        assert deterministic_ability_category(ability) == "reactive"
 
     def test_one_action_is_offensive(self):
         ability = {
@@ -22,7 +22,7 @@ class TestDeterministicCategory:
                 "name": "One Action",
             }
         }
-        assert _deterministic_category(ability) == "offensive"
+        assert deterministic_ability_category(ability) == "offensive"
 
     def test_two_actions_is_offensive(self):
         ability = {
@@ -32,7 +32,7 @@ class TestDeterministicCategory:
                 "name": "Two Actions",
             }
         }
-        assert _deterministic_category(ability) == "offensive"
+        assert deterministic_ability_category(ability) == "offensive"
 
     def test_three_actions_is_offensive(self):
         ability = {
@@ -42,7 +42,7 @@ class TestDeterministicCategory:
                 "name": "Three Actions",
             }
         }
-        assert _deterministic_category(ability) == "offensive"
+        assert deterministic_ability_category(ability) == "offensive"
 
     def test_free_action_with_trigger_is_reactive(self):
         ability = {
@@ -53,7 +53,7 @@ class TestDeterministicCategory:
             },
             "trigger": "An enemy enters your reach.",
         }
-        assert _deterministic_category(ability) == "reactive"
+        assert deterministic_ability_category(ability) == "reactive"
 
     def test_free_action_without_trigger_is_none(self):
         ability = {
@@ -63,15 +63,15 @@ class TestDeterministicCategory:
                 "name": "Free Action",
             }
         }
-        assert _deterministic_category(ability) is None
+        assert deterministic_ability_category(ability) is None
 
     def test_no_action_type_returns_none(self):
         ability = {"name": "Darkvision", "text": "Can see in the dark."}
-        assert _deterministic_category(ability) is None
+        assert deterministic_ability_category(ability) is None
 
     def test_action_type_not_dict_returns_none(self):
         ability = {"action_type": "One Action"}
-        assert _deterministic_category(ability) is None
+        assert deterministic_ability_category(ability) is None
 
     def test_empty_ability_returns_none(self):
-        assert _deterministic_category({}) is None
+        assert deterministic_ability_category({}) is None

--- a/tests/test_enrichment_migrations.py
+++ b/tests/test_enrichment_migrations.py
@@ -1,0 +1,120 @@
+"""Tests for the enrichment DB migration chain, especially v6/v7 creature_types."""
+
+import sqlite3
+
+import pytest
+
+from pfsrd2.sql.enrichment import (
+    _create_db_v_1,
+    _create_db_v_2,
+    _create_db_v_3,
+    _create_db_v_4,
+    _create_db_v_5,
+    _create_db_v_6,
+    _create_db_v_7,
+    get_enrichment_db_connection,
+)
+
+
+@pytest.fixture
+def fresh_conn():
+    conn = get_enrichment_db_connection(db_path=":memory:")
+    yield conn
+    conn.close()
+
+
+class TestFullMigrationChain:
+    def test_fresh_db_ends_at_v7(self, fresh_conn):
+        curs = fresh_conn.cursor()
+        curs.execute("SELECT MAX(version) AS v FROM enrichment_db_version")
+        assert curs.fetchone()["v"] == 7
+
+    def test_creature_types_table_exists_and_is_nocase(self, fresh_conn):
+        curs = fresh_conn.cursor()
+        curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('Undead', 'now')")
+        # Same name, different case — COLLATE NOCASE + UNIQUE should reject
+        with pytest.raises(sqlite3.IntegrityError):
+            curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('undead', 'now')")
+
+    def test_insert_or_ignore_dedupes_case_insensitively(self, fresh_conn):
+        curs = fresh_conn.cursor()
+        curs.execute(
+            "INSERT OR IGNORE INTO creature_types (name, created_at) VALUES ('Undead', 'now')"
+        )
+        curs.execute(
+            "INSERT OR IGNORE INTO creature_types (name, created_at) VALUES ('UNDEAD', 'now')"
+        )
+        curs.execute("SELECT COUNT(*) AS c FROM creature_types")
+        assert curs.fetchone()["c"] == 1
+
+
+class TestMigrationIdempotency:
+    def _raw_conn(self):
+        """A raw sqlite3 connection without running any migrations yet.
+
+        No row_factory — the migration code uses positional row[0] internally.
+        """
+        return sqlite3.connect(":memory:")
+
+    def test_v6_idempotent_when_already_applied(self):
+        conn = self._raw_conn()
+        curs = conn.cursor()
+        ver = _create_db_v_1(conn, curs)
+        ver = _create_db_v_2(conn, curs, ver)
+        ver = _create_db_v_3(conn, curs, ver)
+        ver = _create_db_v_4(conn, curs, ver)
+        ver = _create_db_v_5(conn, curs, ver)
+        ver = _create_db_v_6(conn, curs, ver)
+        assert ver == 6
+        # Re-running v6 should be a no-op
+        again = _create_db_v_6(conn, curs, ver)
+        assert again == 6
+        conn.close()
+
+    def test_v7_idempotent_when_already_applied(self):
+        conn = self._raw_conn()
+        curs = conn.cursor()
+        ver = _create_db_v_1(conn, curs)
+        for fn in (_create_db_v_2, _create_db_v_3, _create_db_v_4, _create_db_v_5):
+            ver = fn(conn, curs, ver)
+        ver = _create_db_v_6(conn, curs, ver)
+        ver = _create_db_v_7(conn, curs, ver)
+        assert ver == 7
+        again = _create_db_v_7(conn, curs, ver)
+        assert again == 7
+        conn.close()
+
+
+class TestV7DropsAndRecreates:
+    def _build_v6_db(self):
+        """Build a raw DB stopped at v6 (no v7 applied), with a case-sensitive
+        creature_types table containing a seeded row."""
+        conn = sqlite3.connect(":memory:")
+        curs = conn.cursor()
+        ver = _create_db_v_1(conn, curs)
+        for fn in (_create_db_v_2, _create_db_v_3, _create_db_v_4, _create_db_v_5):
+            ver = fn(conn, curs, ver)
+        ver = _create_db_v_6(conn, curs, ver)
+        assert ver == 6
+        curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('Undead', 'now')")
+        conn.commit()
+        return conn, curs
+
+    def test_v7_drops_rows_and_enforces_nocase(self):
+        conn, curs = self._build_v6_db()
+        # Before v7, the table has 1 row
+        curs.execute("SELECT COUNT(*) FROM creature_types")
+        assert curs.fetchone()[0] == 1
+
+        ver = _create_db_v_7(conn, curs, 6)
+        assert ver == 7
+
+        # Rows dropped by the rebuild (documented behavior — re-seed required)
+        curs.execute("SELECT COUNT(*) FROM creature_types")
+        assert curs.fetchone()[0] == 0
+
+        # New table is case-insensitive
+        curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('Undead', 'now')")
+        with pytest.raises(sqlite3.IntegrityError):
+            curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('undead', 'now')")
+        conn.close()

--- a/tests/test_enrichment_migrations.py
+++ b/tests/test_enrichment_migrations.py
@@ -1,4 +1,4 @@
-"""Tests for the enrichment DB migration chain, especially v6/v7 creature_types."""
+"""Tests for the enrichment DB migration chain, especially v6 creature_types."""
 
 import sqlite3
 
@@ -11,7 +11,6 @@ from pfsrd2.sql.enrichment import (
     _create_db_v_4,
     _create_db_v_5,
     _create_db_v_6,
-    _create_db_v_7,
     get_enrichment_db_connection,
 )
 
@@ -24,10 +23,10 @@ def fresh_conn():
 
 
 class TestFullMigrationChain:
-    def test_fresh_db_ends_at_v7(self, fresh_conn):
+    def test_fresh_db_ends_at_v6(self, fresh_conn):
         curs = fresh_conn.cursor()
         curs.execute("SELECT MAX(version) AS v FROM enrichment_db_version")
-        assert curs.fetchone()["v"] == 7
+        assert curs.fetchone()["v"] == 6
 
     def test_creature_types_table_exists_and_is_nocase(self, fresh_conn):
         curs = fresh_conn.cursor()
@@ -60,61 +59,11 @@ class TestMigrationIdempotency:
         conn = self._raw_conn()
         curs = conn.cursor()
         ver = _create_db_v_1(conn, curs)
-        ver = _create_db_v_2(conn, curs, ver)
-        ver = _create_db_v_3(conn, curs, ver)
-        ver = _create_db_v_4(conn, curs, ver)
-        ver = _create_db_v_5(conn, curs, ver)
+        for fn in (_create_db_v_2, _create_db_v_3, _create_db_v_4, _create_db_v_5):
+            ver = fn(conn, curs, ver)
         ver = _create_db_v_6(conn, curs, ver)
         assert ver == 6
         # Re-running v6 should be a no-op
         again = _create_db_v_6(conn, curs, ver)
         assert again == 6
-        conn.close()
-
-    def test_v7_idempotent_when_already_applied(self):
-        conn = self._raw_conn()
-        curs = conn.cursor()
-        ver = _create_db_v_1(conn, curs)
-        for fn in (_create_db_v_2, _create_db_v_3, _create_db_v_4, _create_db_v_5):
-            ver = fn(conn, curs, ver)
-        ver = _create_db_v_6(conn, curs, ver)
-        ver = _create_db_v_7(conn, curs, ver)
-        assert ver == 7
-        again = _create_db_v_7(conn, curs, ver)
-        assert again == 7
-        conn.close()
-
-
-class TestV7DropsAndRecreates:
-    def _build_v6_db(self):
-        """Build a raw DB stopped at v6 (no v7 applied), with a case-sensitive
-        creature_types table containing a seeded row."""
-        conn = sqlite3.connect(":memory:")
-        curs = conn.cursor()
-        ver = _create_db_v_1(conn, curs)
-        for fn in (_create_db_v_2, _create_db_v_3, _create_db_v_4, _create_db_v_5):
-            ver = fn(conn, curs, ver)
-        ver = _create_db_v_6(conn, curs, ver)
-        assert ver == 6
-        curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('Undead', 'now')")
-        conn.commit()
-        return conn, curs
-
-    def test_v7_drops_rows_and_enforces_nocase(self):
-        conn, curs = self._build_v6_db()
-        # Before v7, the table has 1 row
-        curs.execute("SELECT COUNT(*) FROM creature_types")
-        assert curs.fetchone()[0] == 1
-
-        ver = _create_db_v_7(conn, curs, 6)
-        assert ver == 7
-
-        # Rows dropped by the rebuild (documented behavior — re-seed required)
-        curs.execute("SELECT COUNT(*) FROM creature_types")
-        assert curs.fetchone()[0] == 0
-
-        # New table is case-insensitive
-        curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('Undead', 'now')")
-        with pytest.raises(sqlite3.IntegrityError):
-            curs.execute("INSERT INTO creature_types (name, created_at) VALUES ('undead', 'now')")
         conn.close()

--- a/tests/test_seed_creature_types.py
+++ b/tests/test_seed_creature_types.py
@@ -1,0 +1,133 @@
+"""Tests for bin/pf2_seed_creature_types."""
+
+import importlib.util
+import json
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+
+def _load_seed_module():
+    """Load the seed script as a module (it has no .py extension)."""
+    path = Path(__file__).resolve().parents[1] / "bin" / "pf2_seed_creature_types"
+    loader = SourceFileLoader("pf2_seed_creature_types", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+seed = _load_seed_module()
+
+
+def _write_monster(data_dir, rel, creature_types):
+    """Helper: write a minimal monster JSON with the given creature_types."""
+    path = Path(data_dir) / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"stat_block": {"creature_type": {"creature_types": creature_types}}})
+    )
+
+
+class TestIterCreatureTypeNames:
+    def test_yields_from_monsters_and_npcs(self, tmp_path):
+        _write_monster(tmp_path, "monsters/bestiary/goblin.json", ["Goblin", "Humanoid"])
+        _write_monster(tmp_path, "npcs/core/guard.json", ["Human"])
+        result = list(seed._iter_creature_type_names(str(tmp_path)))
+        assert "Goblin" in result
+        assert "Humanoid" in result
+        assert "Human" in result
+
+    def test_malformed_json_is_skipped_with_warning(self, tmp_path, capsys):
+        good = tmp_path / "monsters/bestiary/ok.json"
+        good.parent.mkdir(parents=True)
+        good.write_text(
+            json.dumps({"stat_block": {"creature_type": {"creature_types": ["Aberration"]}}})
+        )
+        bad = tmp_path / "monsters/bestiary/bad.json"
+        bad.write_text("{ this is not json")
+
+        result = list(seed._iter_creature_type_names(str(tmp_path)))
+
+        assert result == ["Aberration"]
+        err = capsys.readouterr().err
+        assert "bad.json" in err
+        assert "skipping" in err
+
+    def test_unwraps_dict_name_entries(self, tmp_path):
+        path = tmp_path / "monsters/bestiary/fancy.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "stat_block": {
+                        "creature_type": {"creature_types": [{"name": "Dragon"}, {"name": "Fire"}]}
+                    }
+                }
+            )
+        )
+        assert list(seed._iter_creature_type_names(str(tmp_path))) == ["Dragon", "Fire"]
+
+    def test_filters_blank_and_non_string_names(self, tmp_path):
+        _write_monster(tmp_path, "monsters/bestiary/weird.json", ["", "   ", None, "Valid"])
+        assert list(seed._iter_creature_type_names(str(tmp_path))) == ["Valid"]
+
+    def test_strips_whitespace(self, tmp_path):
+        _write_monster(tmp_path, "monsters/bestiary/sp.json", ["  Undead  "])
+        assert list(seed._iter_creature_type_names(str(tmp_path))) == ["Undead"]
+
+
+class TestSeedMain:
+    def test_exits_2_with_no_arg_and_no_env(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["pf2_seed_creature_types"])
+        monkeypatch.delenv("PF2_DATA_DIR", raising=False)
+        assert seed.main() == 2
+
+    def test_exits_2_on_missing_dir(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["pf2_seed_creature_types", "/does/not/exist/xyz"])
+        monkeypatch.delenv("PF2_DATA_DIR", raising=False)
+        assert seed.main() == 2
+
+    def test_dedups_before_upsert(self, tmp_path, monkeypatch, capsys):
+        # Same name appears in two files; main's `seen` set should upsert once.
+        _write_monster(tmp_path, "monsters/a/a.json", ["Undead"])
+        _write_monster(tmp_path, "monsters/b/b.json", ["Undead", "Dragon"])
+
+        upsert_calls = []
+
+        def fake_upsert(curs, name):
+            upsert_calls.append(name)
+
+        # In-memory DB via real get_enrichment_db_connection
+        from pfsrd2.sql.enrichment import get_enrichment_db_connection
+
+        memdb = get_enrichment_db_connection(db_path=":memory:")
+        monkeypatch.setattr(seed, "get_enrichment_db_connection", lambda: memdb)
+        monkeypatch.setattr(seed, "upsert_creature_type", fake_upsert)
+        # fetch_all_creature_types is called for before/after snapshots; stub
+        # it to empty sets so main's diff print doesn't matter.
+        monkeypatch.setattr(seed, "fetch_all_creature_types", lambda curs: set())
+
+        monkeypatch.setattr(sys, "argv", ["pf2_seed_creature_types", str(tmp_path)])
+        rc = seed.main()
+
+        assert rc == 0
+        assert sorted(upsert_calls) == ["Dragon", "Undead"]  # no duplicate "Undead"
+
+    def test_reads_from_env_when_no_argv(self, tmp_path, monkeypatch):
+        _write_monster(tmp_path, "monsters/a/a.json", ["Goblin"])
+
+        from pfsrd2.sql.enrichment import get_enrichment_db_connection
+
+        memdb = get_enrichment_db_connection(db_path=":memory:")
+        monkeypatch.setattr(seed, "get_enrichment_db_connection", lambda: memdb)
+
+        recorded = []
+        monkeypatch.setattr(seed, "upsert_creature_type", lambda c, n: recorded.append(n))
+        monkeypatch.setattr(seed, "fetch_all_creature_types", lambda c: set())
+
+        monkeypatch.setattr(sys, "argv", ["pf2_seed_creature_types"])
+        monkeypatch.setenv("PF2_DATA_DIR", str(tmp_path))
+
+        assert seed.main() == 0
+        assert recorded == ["Goblin"]


### PR DESCRIPTION
## Summary

Three correctness fixes for template/family change enrichment, plus a small architectural change to make creature-type trait routing data-driven.

**Per-ability effect routing** (PFSRD2-Parser-ixvb). `_build_effects` for `change_category='abilities'` dumped every added ability into `$.defense.automatic_abilities`. The Amphibious template placed Drag Along (a one-action offensive ability) next to Low-light Vision (a special sense). Now emits one effect per ability, categorized by action type (deterministic) with a DB lookup fallback.

**Restored spell effect emissions** (PFSRD2-Parser-j7ko, -97fv). Elite/Weak templates stopped bumping spell attack rolls and stopped annotating spell damage for limited-use abilities. The old cached `enriched_json` had these targets, but current code didn't emit them (ENRICHMENT_VERSION was never bumped after the refactor that dropped them). `$.offense.offensive_actions[*].spells.spell_attack` is populated on 627+ monsters, so this is real data. `spells.notes` gets a string annotation for limited-use because spells have no single integer damage field.

**Creature types in enrichment DB** (PFSRD2-Parser-rg1j). `_trait_target` used a 22-entry hardcoded set that missed ancestries (Vampire, Skeleton, Human, ...) and subtypes (Air, Fire, Aquatic, Unholy, ...). Real monster data has 221 distinct creature types. The previous a10f0f4 routing fix silently dropped these to `$.traits` only when they should also land in `$.creature_type.creature_types`. New `creature_types` table (v6 migration); `creatures.creature_type_db_pass` upserts every type seen; seed script reads existing output to bootstrap.

`ENRICHMENT_VERSION` 17 → 19.

## Test plan

- [x] 1125 tests pass (7 added)
- [x] `bin/pf2_seed_creature_types` seeded 221 names from `pfsrd2-data/monsters` + `npcs`
- [x] `bin/pf2_run_monster_templates.sh` clean (0 errors)
- [x] `bin/pf2_run_monster_families.sh` clean (0 errors)
- [x] Amphibious template: Drag Along → `$.offense.offensive_actions`, Low-light Vision → `$.senses.special_senses`
- [x] Elite template: `spells.spell_attack` +2 adjustment restored; `spells.notes` "+4 damage (Elite, limited use)" restored
- [x] Vampire trait routes to `$.creature_type.creature_types` (DB-backed)
- [x] Rare/Uncommon route to `$.traits` (not creature types)

## Filed for follow-up (not in this PR)

**PFSRD2-Parser-q0gh** — `_categorize_change_text` misclassifies long ability-description blocks as `traits` changes, causing junk link extractions (Concentrate/Action/Revulsion/Condition from the vampire Revulsion ability) to appear as trait `add_item`s in ~10 vampire-related families. Bug pre-dates this PR; both old and new targets for these names are wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)