### PR TITLE
feat: granting ability sections become changes (Broodpiercer host abilities)

### DIFF
--- a/pfsrd2/monster_template.py
+++ b/pfsrd2/monster_template.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 
 from bs4 import BeautifulSoup
@@ -20,6 +21,7 @@ from universal.markdown import markdown_pass as universal_markdown_pass
 from universal.monster_ability import monster_ability_db_pass
 from universal.universal import (
     aon_pass,
+    build_object,
     entity_pass,
     extract_source_from_bs,
     game_id_pass,
@@ -31,6 +33,10 @@ from universal.universal import (
     source_pass,
 )
 from universal.utils import get_text, remove_empty_fields, strip_block_tags
+
+# Section intros that unconditionally grant their abilities (vs choose-from
+# pools, which the engine must never auto-apply).
+_GRANTS_ABILITIES = re.compile(r"gains? the following abilit", re.IGNORECASE)
 
 
 def parse_monster_template(filename, options):
@@ -208,8 +214,23 @@ def _try_extract_changes(source_section, mt):
     # abilities after the </ul>)
     abilities = _extract_abilities_from_bs(bs)
     if abilities:
-        source_section["text"] = str(bs).strip()
-        mt.setdefault("abilities", []).extend(abilities)
+        remaining = str(bs).strip()
+        source_section["text"] = remaining
+        # A section that GRANTS its abilities unconditionally ("All host
+        # creatures gain the following abilities.") is a construction
+        # instruction like any <li>: emit it as a change so enrichment
+        # builds placement effects. Choose-from pools ("one of the
+        # following") and plain ability sections stay at mt.abilities —
+        # the engine only auto-applies those when the template has no
+        # changes at all, which is exactly the ability-only case.
+        if source_section is not mt and _GRANTS_ABILITIES.search(get_text(bs)):
+            change = build_object("stat_block_section", "change", "")
+            del change["name"]
+            change["text"] = remaining
+            change["abilities"] = abilities
+            mt.setdefault("changes", []).append(change)
+        else:
+            mt.setdefault("abilities", []).extend(abilities)
         found = True
     return found
 

--- a/pfsrd2/monster_template.py
+++ b/pfsrd2/monster_template.py
@@ -36,7 +36,7 @@ from universal.utils import get_text, remove_empty_fields, strip_block_tags
 
 # Section intros that unconditionally grant their abilities (vs choose-from
 # pools, which the engine must never auto-apply).
-_GRANTS_ABILITIES = re.compile(r"gains? the following abilit", re.IGNORECASE)
+_GRANTS_ABILITIES = re.compile(r"\bgains?\s+the\s+following\s+abilit", re.IGNORECASE)
 
 
 def parse_monster_template(filename, options):
@@ -198,7 +198,7 @@ def _try_extract_changes(source_section, mt):
     bs = BeautifulSoup(source_section["text"], "html.parser")
     found = False
     ul = bs.find("ul")
-    if ul and "changes" not in mt:
+    if ul and not mt.get("_ul_changes_extracted"):
         changes = []
         for li in ul.find_all("li", recursive=False):
             if not get_text(li).strip():
@@ -207,7 +207,10 @@ def _try_extract_changes(source_section, mt):
             changes.append(change)
         ul.decompose()
         source_section["text"] = str(bs).strip()
-        mt["changes"] = changes
+        # granting ability sections may have appended changes already —
+        # the <li> changes are the template's primary list and go first
+        mt["changes"] = changes + mt.get("changes", [])
+        mt["_ul_changes_extracted"] = True
         found = True
     # Check for inline abilities — either when there's no <ul>, or in
     # remaining text after the <ul> was removed (ancestry templates put
@@ -224,9 +227,16 @@ def _try_extract_changes(source_section, mt):
         # the engine only auto-applies those when the template has no
         # changes at all, which is exactly the ability-only case.
         if source_section is not mt and _GRANTS_ABILITIES.search(get_text(bs)):
+            # Mirror parse_change: links must be extracted before the text
+            # is captured — raw <a> in change text fails markdown validation.
+            links = get_links(bs, unwrap=True)
+            remaining = str(bs).strip()
+            source_section["text"] = remaining
             change = build_object("stat_block_section", "change", "")
             del change["name"]
             change["text"] = remaining
+            if links:
+                change["links"] = links
             change["abilities"] = abilities
             mt.setdefault("changes", []).append(change)
         else:
@@ -320,6 +330,7 @@ def monster_template_cleanup_pass(struct):
         del mt["links"]
     if "sections" in mt:
         del mt["sections"]
+    mt.pop("_ul_changes_extracted", None)
     _clean_html_fields(struct)
 
 

--- a/pfsrd2/monster_template.py
+++ b/pfsrd2/monster_template.py
@@ -36,7 +36,12 @@ from universal.utils import get_text, remove_empty_fields, strip_block_tags
 
 # Section intros that unconditionally grant their abilities (vs choose-from
 # pools, which the engine must never auto-apply).
-_GRANTS_ABILITIES = re.compile(r"\bgains?\s+the\s+following\s+abilit", re.IGNORECASE)
+_GRANTS_ABILITIES = re.compile(
+    # Unconditional grants only: modal wording ("may/can/might gain the
+    # following abilities") is a choice, not a grant, and must stay pooled.
+    r"(?<!\bmay )(?<!\bcan )(?<!\bmight )\bgains?\s+the\s+following\s+abilit",
+    re.IGNORECASE,
+)
 
 
 def parse_monster_template(filename, options):

--- a/tests/test_section_granted_abilities.py
+++ b/tests/test_section_granted_abilities.py
@@ -83,3 +83,14 @@ class TestSectionGrantedAbilities:
         texts = [c["text"] for c in mt["changes"]]
         assert "Increase the creature's level" in texts[0]
         assert texts[1].startswith("All host creatures gain")
+
+    def test_modal_grant_stays_pool(self):
+        # "may gain the following abilities" is a choice, not a grant.
+        mt = {"name": "X"}
+        section = _section(
+            "The creature may gain the following abilities.<br/>"
+            "<b>Optional Thing</b> Something optional."
+        )
+        assert _try_extract_changes(section, mt)
+        assert "changes" not in mt
+        assert mt["abilities"][0]["name"] == "Optional Thing"

--- a/tests/test_section_granted_abilities.py
+++ b/tests/test_section_granted_abilities.py
@@ -53,3 +53,33 @@ class TestSectionGrantedAbilities:
         assert _try_extract_changes(mt, mt)
         assert "changes" not in mt
         assert len(mt["abilities"]) == 2
+
+    def test_granting_with_links_extracts_links(self):
+        mt = {"name": "Experimental Cryptid"}
+        html = (
+            'A cryptid gains the <a aonid="6" game-obj="Traits">alchemical</a> '
+            "trait. An experimental cryptid gains the following abilities.<br/>"
+            "<b>Augmented</b> Body parts replaced."
+        )
+        section = _section(html)
+        assert _try_extract_changes(section, mt)
+        change = mt["changes"][0]
+        assert "<a" not in change["text"]
+        assert change["links"][0]["name"] == "alchemical"
+
+    def test_granting_with_no_parseable_abilities_is_noop(self):
+        mt = {"name": "X"}
+        section = _section("All hosts gain the following abilities. Nothing here.")
+        assert not _try_extract_changes(section, mt)
+        assert "changes" not in mt
+
+    def test_grant_before_ul_keeps_li_changes_first(self):
+        # A granting section processed before the <ul> section must neither
+        # block <li> extraction nor displace the primary change list.
+        mt = {"name": "X"}
+        assert _try_extract_changes(_section(GRANTING), mt)
+        ul_section = _section("<ul><li>Increase the creature's level by 1.</li></ul>")
+        assert _try_extract_changes(ul_section, mt)
+        texts = [c["text"] for c in mt["changes"]]
+        assert "Increase the creature's level" in texts[0]
+        assert texts[1].startswith("All host creatures gain")

--- a/tests/test_section_granted_abilities.py
+++ b/tests/test_section_granted_abilities.py
@@ -1,0 +1,55 @@
+from pfsrd2.monster_template import _try_extract_changes
+
+
+def _section(text):
+    return {"name": "Host Abilities", "text": text, "sections": []}
+
+
+GRANTING = (
+    "All host creatures gain the following abilities.<br/>"
+    "<b>Cold Stasis</b> The creature is vulnerable to cold.<br/>"
+    "<b>Fumbling Dodge</b> <span class='action' title='Reaction'></span> "
+    "The creature ducks awkwardly."
+)
+
+CHOOSING = (
+    "The creature gains one of the following mutations.<br/>"
+    "<b>Unusual Bane</b> Choose a creature type.<br/>"
+    "<b>Explosive End</b> When the creature dies, it explodes."
+)
+
+
+class TestSectionGrantedAbilities:
+    def test_granting_section_becomes_change(self):
+        # "gain the following abilities" is a construction instruction: the
+        # engine only auto-applies mt.abilities for templates with no changes
+        # at all, so Broodpiercer's host abilities were silently dropped when
+        # they lived at mt.abilities alongside its stat changes.
+        mt = {"name": "Broodpiercer"}
+        section = _section(GRANTING)
+        assert _try_extract_changes(section, mt)
+        assert "abilities" not in mt
+        changes = mt["changes"]
+        assert len(changes) == 1
+        assert changes[0]["text"].startswith("All host creatures gain")
+        names = [a["name"] for a in changes[0]["abilities"]]
+        assert names == ["Cold Stasis", "Fumbling Dodge"]
+
+    def test_choosing_section_stays_pool(self):
+        # Choose-from pools must never become auto-applied changes.
+        mt = {"name": "Mutant Cryptid"}
+        section = _section(CHOOSING)
+        assert _try_extract_changes(section, mt)
+        assert "changes" not in mt
+        assert [a["name"] for a in mt["abilities"]] == [
+            "Unusual Bane",
+            "Explosive End",
+        ]
+
+    def test_stat_block_inline_abilities_stay_pool(self):
+        # Abilities inline in the stat block itself (source_section is mt)
+        # keep the existing pool behavior even with granting wording.
+        mt = {"name": "X", "text": GRANTING}
+        assert _try_extract_changes(mt, mt)
+        assert "changes" not in mt
+        assert len(mt["abilities"]) == 2


### PR DESCRIPTION
## Summary

Clause-level verification caught a real regression from the template-fixes regeneration: **Broodpiercer's four host abilities never apply**. The engine synthesizes the implicit abilities change only for templates with *no* changes at all (Twinned, the four Mythics — verified green), so Broodpiercer — stat changes + a section-based grant — left its pool unconsumed.

Fix: `_try_extract_changes` now converts an ability section whose intro matches `gain(s) the following abilit…` into a proper change — text is the section's real intro sentence ("All host creatures gain the following abilities."), abilities attached, and the standard enrich → re-parse cycle builds the placement effects. Explicitly excluded: choose-from pools (Dark Archive cryptids — must never auto-apply; verified they still parse to `mt.abilities`) and inline stat-block abilities (`source_section is mt`).

Blast radius: grep over all 55 templates shows Broodpiercer is the only granting section.

## Testing
- 3 new tests: granting section → change; choosing section → pool; stat-block-inline → pool.
- Broodpiercer dry-run parse: 5 changes incl. the granting change with all 4 abilities; cryptid (ID_31) regression-checked unchanged.
- Full suite 1190 passing; ruff/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)